### PR TITLE
remove personal email, tweak copy

### DIFF
--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -14,7 +14,7 @@
     <ul class="nav navbar-nav navbar-right">
       <li><%= link_to "About", about_path %></li>
       <li><%= link_to "FAQ", faq_path %></li>
-      <li><%= mail_to "matt.ewell@gmail.com", "Contact" %></li>
+      <li><%= mail_to "admin@denvermeetings.org", "Contact" %></li>
     </ul>
   </div><!--/.nav-collapse -->
 </div>

--- a/app/views/welcome/about.html.erb
+++ b/app/views/welcome/about.html.erb
@@ -5,13 +5,16 @@
         <h1 class="text-left">About</h1>
       </div>
 
-      <p>Thank you for visiting Denver Meetings! This site is the realization of a years-old dream. It is a work in progress, but I hope that you already find it to be of use! Please provide any feedback <%= mail_to "matt.ewell@gmail.com", "here" %>.
+      <p>
+        Thank you for visiting Denver Meetings! This site is the realization of a years-old dream to list Alcohlics Anonymous meetings in metro Denver in a user-friendly format. While the information on daccaa.org is great, the creator of this site and many others found AA meeting listings difficult to find.</p>
+      <p>
+        The biggest pain points we are trying to address are finding meetings from a mobile device, and finding meetings relative to a location. It is a work in progress, but we hope that you already find it to be of use! Please provide any feedback or just drop a note to say hello <%= mail_to "admin@denvermeetings.org", "here" %>.
       </p>
       <p>
-        Disclaimer: This site is not affiliated with Alcoholics Anonymous or any 12-step group. These listings are provided as a service only. No warranty is given or implied. Information found here is provided "as is" and is not intended to diagnose, prevent, or treat any disease.
+        Disclaimer: This site is not affiliated with Alcoholics Anonymous, Denver Area Central Committee of Alcoholics Anonymous (daccaa.org) or any 12-step group. These listings are provided as a service only. No warranty is given or implied. Information found here is provided "as is" and is not intended to diagnose, prevent, or treat any disease.
       </p>
       <p>
-        If you have a drinking problem, there is help. But you have to ask. Welcome!
+        If you have a drinking problem, there is help. But you may have to take some action. Welcome!
       </p>
 
 

--- a/app/views/welcome/faq.html.erb
+++ b/app/views/welcome/faq.html.erb
@@ -18,7 +18,7 @@
         </div>
         <div id="collapseOne" class="panel-collapse collapse">
           <div class="panel-body">
-          No, this site is not affiliated with Alcoholics Anonymous or any 12-step group. These listings are provided as a service only. No warranty is given or implied. Information found here is provided "as is" and is not intended to diagnose, prevent, or treat any disease.
+          No, this site is not affiliated with Alcoholics Anonymous or any 12-step group. This site is not affiliated with Denver Area Central Committee of Alcoholics Anonymous or daccaa.org. These listings are provided as a service only. No warranty is given or implied. Information found here is provided "as is" and is not intended to diagnose, prevent, or treat any disease.
           </div>
         </div>
       </div>
@@ -33,7 +33,7 @@
         </div>
         <div id="collapseFive" class="panel-collapse collapse">
           <div class="panel-body">
-          At the time this was written, I am open to consulting or full-time employment opportunities. Please use the contact link or click <%= mail_to "matt.ewell@gmail.com", "here" %>.
+          The creator of this site is employed full time and maintains this site as an avocation. You may contact them at <%= mail_to "admin@denvermeetings.org", "admin@denvermeetings.org" %>.
           </div>
         </div>
       </div>
@@ -63,7 +63,7 @@
         </div>
         <div id="collapseSeven" class="panel-collapse collapse">
           <div class="panel-body">
-          That is frustrating and I apologize for any inconvenience. The best thing to do would be to double-check the listing on <%= link_to "Denver AA's site", "http://www.daccaa.org/meetings.htm" %>. If the information is correct there and incorrect on this site, I am very interested to know. Please contact me <%= mail_to "matt.ewell@gmail.com", "here" %>. If the information with Denver AA is incorrect, please update them, and this site will be updated automatically. As a reminder, this site is not affiliated with AA at any level.
+          That is frustrating and we apologize for any inconvenience. The best thing to do would be to check the listing on <%= link_to "Denver AA's site", "http://www.daccaa.org/meetings.htm" %>. If the information is correct there and incorrect on this site, <%= mail_to "admin@denvermeetings.org", "please let us know" %>. If the information with Denver AA is incorrect, please update them, and this site will be updated automatically. As a reminder, this site is not affiliated with AA at any level.
           </div>
         </div>
       </div>


### PR DESCRIPTION
i don't like the looks of the about page, especially. but this change at least gets better email addresses, and describes more specifically what the site is about and why it is here.