### PR TITLE
Meeting show closes #33 closes #91

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,7 +1,7 @@
 class WelcomeController < ApplicationController
 
   def faq
-
+    params[:expand] = params[:expand].presence
   end
 
   def about

--- a/app/models/mobile_meeting_display.rb
+++ b/app/models/mobile_meeting_display.rb
@@ -22,6 +22,18 @@ class MobileMeetingDisplay
     Day.day_to_int[self.meeting.day]
   end
 
+  def language
+    self.meeting.languages.to_a.map(&:name).join(", ")
+  end
+
+  def features
+    self.meeting.features.to_a.map(&:name).join(", ")
+  end
+
+  def foci
+    self.meeting.foci.to_a.map(&:name).join(", ")
+  end
+
   def group_name
     meeting.group_name
   end

--- a/app/views/mobile/search/_meeting.html.erb
+++ b/app/views/mobile/search/_meeting.html.erb
@@ -1,0 +1,19 @@
+<%# cache(meeting.meeting) do %>
+  <li><%= meeting_without_distance(meeting) %></li>
+  <li>
+    <% if meeting.closed? %>
+      <%= link_to "Closed to alcoholics only", faq_path(:expand => "open-closed"), {'data-role' => 'button', 'data-icon' => 'info'} %>
+    <% else %>
+      <%= link_to "Open to non-alcoholics", faq_path(:expand => "open-closed"), {'data-role' => 'button', 'data-icon' => 'info', "data-iconpos" => "right", "data-ajax" => "false", "rel" => "external"} %>
+    <% end %>
+  </li>
+  <% if meeting.language.length > 0 %>
+    <li><strong><%= "Language: " %></strong><%= meeting.language %></li>
+  <% end %>
+  <% if meeting.features.length > 0 %>
+    <li><strong><%= "Features: " %></strong><%= meeting.features %></li>
+  <% end %>
+  <% if meeting.foci.length > 0 %>
+    <li><strong><%= "Special Focus: " %></strong><%= meeting.foci %></li>
+  <% end %> 
+<%# end %>

--- a/app/views/mobile/search/_proximal_meeting.html.erb
+++ b/app/views/mobile/search/_proximal_meeting.html.erb
@@ -1,0 +1,1 @@
+<li><%= meeting_with_distance(meeting) %></li>

--- a/app/views/mobile/search/index.html.erb
+++ b/app/views/mobile/search/index.html.erb
@@ -1,5 +1,5 @@
 <div data-role="header" data-theme="b">
-  <h1>Meetings Found<span class="ui-li-count"><%= meeting_count(@meetings) %></span></h1>
+  <h1>Search Results<span class="ui-li-count"><%= meeting_count(@meetings) %> Meetings</span></h1>
 </div>
 <div data-role="content" data-theme="b" id="search-results-main">
   <ul data-role="listview">
@@ -11,11 +11,9 @@
             <h2><%= "#{meeting.group_name} #{meeting.time}" %></h2>
             <ul data-role="listview" data-inset="true">
             <% if distance_display?(group.first) %>
-              <li><%= meeting_with_distance(meeting) %></li>
+              <%= render "proximal_meeting", meeting: meeting %>
             <% else %>
-              <% cache(meeting.meeting) do %>
-                <li><%= meeting_without_distance(meeting) %></li>
-              <% end %>
+              <%= render "meeting", meeting: meeting %>
             <% end %>
             <li><%= link_to raw(meeting.address), meeting.map_url, {:class => "ui-icon-location", :target => "_blank"} %></li>
             </ul>

--- a/app/views/mobile/search/index.html.erb
+++ b/app/views/mobile/search/index.html.erb
@@ -1,5 +1,5 @@
-<div data-role="header" data-theme="b">
-  <h1>Search Results<span class="ui-li-count"><%= meeting_count(@meetings) %> Meetings</span></h1>
+<div data-role="header" data-theme="b" data-add-back-btn="true">
+  <%= link_to "New Search", new_mobile_search_path, {"data-icon" => "back", "data-theme" => "c"} %><h1>Search Results<span class="ui-li-count"><%= pluralize(meeting_count(@meetings), "Meeting") %></span></h1>
 </div>
 <div data-role="content" data-theme="b" id="search-results-main">
   <ul data-role="listview">

--- a/app/views/mobile/search/index.html.erb
+++ b/app/views/mobile/search/index.html.erb
@@ -1,5 +1,5 @@
 <div data-role="header" data-theme="b" data-add-back-btn="true">
-  <%= link_to "New Search", new_mobile_search_path, {"data-icon" => "back", "data-theme" => "c"} %><h1>Search Results<span class="ui-li-count"><%= pluralize(meeting_count(@meetings), "Meeting") %></span></h1>
+  <%= link_to "New Search", new_mobile_search_path, {"data-icon" => "back"} %><h1>Search Results<span class="ui-li-count"><%= pluralize(meeting_count(@meetings), "Meeting") %></span></h1>
 </div>
 <div data-role="content" data-theme="b" id="search-results-main">
   <ul data-role="listview">

--- a/app/views/mobile/search/new.html.erb
+++ b/app/views/mobile/search/new.html.erb
@@ -1,5 +1,5 @@
 <div data-role="header" data-theme="b" data-position="fixed" data-tap-toggle="false">
-  <h1>Find a Meeting</h1>
+  <h1>Find a Meeting</h1><%= link_to "Home", root_path, {"data-icon" => "home"} %>
 </div>
 
 <div data-role="content" data-theme="b" role="main">

--- a/app/views/welcome/faq.html.erb
+++ b/app/views/welcome/faq.html.erb
@@ -41,7 +41,7 @@
       <div class="panel panel-default">
         <div class="panel-heading">
           <h4 class="panel-title">
-          <a data-toggle="collapse" data-parent="#accordion" href="#collapseSix">
+          <a data-toggle="collapse" data-parent="#accordion" id="can-i-attend" href="#collapseSix">
           I'm not an alcoholic. Can I attend an AA meeting?
           </a>
           </h4>
@@ -56,12 +56,27 @@
       <div class="panel panel-default">
         <div class="panel-heading">
           <h4 class="panel-title">
-          <a data-toggle="collapse" data-parent="#accordion" href="#collapseSeven">
-          This information is incorrect. Can you fix it?
+          <a data-toggle="collapse" data-parent="#accordion" id="open-closed" href="#collapseSeven">
+          What's an open meeting? What's a closed meeting?
           </a>
           </h4>
         </div>
         <div id="collapseSeven" class="panel-collapse collapse">
+          <div class="panel-body">
+          Meetings designated as closed are for people with a desire to stop drinking, and only for people with a desire to stop drinking. Sometimes this is interpreted by groups as the necessity to admit you are an alcoholic in order to attend. Meetings designated as "open" are generally open to anyone, although some may restrict sharing to those with a desire to stop drinking.
+          </div>
+        </div>
+      </div>
+
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h4 class="panel-title">
+          <a data-toggle="collapse" data-parent="#accordion" href="#collapseEight">
+          This information is incorrect. Can you fix it?
+          </a>
+          </h4>
+        </div>
+        <div id="collapseEight" class="panel-collapse collapse">
           <div class="panel-body">
           That is frustrating and we apologize for any inconvenience. The best thing to do would be to check the listing on <%= link_to "Denver AA's site", "http://www.daccaa.org/meetings.htm" %>. If the information is correct there and incorrect on this site, <%= mail_to "admin@denvermeetings.org", "please let us know" %>. If the information with Denver AA is incorrect, please update them, and this site will be updated automatically. As a reminder, this site is not affiliated with AA at any level.
           </div>
@@ -73,3 +88,10 @@
   </div>
 <div class="col-sm-2"></div>
 </div>
+
+<%= javascript_tag do %>
+  $(document).ready(function() {
+    var expand = $( "#<%= params[:expand] %>" );
+    if (expand.length) { expand.click(); }
+  });
+<% end %>

--- a/spec/features/search_from_landing_spec.rb
+++ b/spec/features/search_from_landing_spec.rb
@@ -15,7 +15,6 @@ RSpec.feature "Search from landing" do
       click_link_or_button "meetings-button"
       expect(page).to have_content("Find a Meeting")
       click_link_or_button "Search"
-      expect(page).to have_content("Meetings Found")
       expect(page).to have_content("Tuesday")
     end
   end


### PR DESCRIPTION
Good little branch here. Adding much more detail to the expansion of a meeting in search results. One of those easy things that just wasn't done initially, and now probably can stand to be reworked, but it's at least there. The same goes from some back navigation in search and search results, going to home and search, respectively.