### PR TITLE
rework header/footer

### DIFF
--- a/app/views/layouts/mobile.html.haml
+++ b/app/views/layouts/mobile.html.haml
@@ -9,4 +9,3 @@
   %body
     #p1{"data-role" => "page"}
       = yield
-      = render partial: 'layouts/mobile/footer'

--- a/app/views/layouts/mobile/_footer.html.haml
+++ b/app/views/layouts/mobile/_footer.html.haml
@@ -1,8 +1,0 @@
-%footer{ 'data-role': "footer", 'data-theme': "b" }
-  .ui-grid-d
-    .ui-block-a
-    .ui-block-b
-    .ui-block-c
-      != "Copyright &copy; 2015"
-    .ui-block-d
-    .ui-clock-e

--- a/app/views/mobile/search/_footer.html.haml
+++ b/app/views/mobile/search/_footer.html.haml
@@ -1,0 +1,5 @@
+%footer{ 'data-role' => "footer", 'data-theme' => "b", 'style' => "text-align:center;", "data-tap-toggle" => "true" }
+  %div{ 'data-role' => "controlgroup", 'data-type' => "horizontal" }
+    = link_to "Back", :back, { class: "ui-btn ui-corner-all ui-shadow ui-icon-arrow-l ui-btn-icon-notext" }
+    = link_to "New", new_mobile_search_path, { class: "ui-btn ui-corner-all ui-shadow ui-icon-back ui-btn-icon-notext" }
+    = link_to "Home", root_path, { class: "ui-btn ui-corner-all ui-shadow ui-icon-home ui-btn-icon-notext" }

--- a/app/views/mobile/search/index.html.haml
+++ b/app/views/mobile/search/index.html.haml
@@ -1,8 +1,6 @@
-%div{"data-add-back-btn" => "true", "data-role" => "header", "data-theme" => "b"}
-  = link_to "New", new_mobile_search_path, {"data-icon" => "back"}
+%div{"data-role" => "header", "data-theme" => "b"}
   %h1
-    Results
-    %span.ui-li-count= "#{meeting_count(@meetings)}"
+    = "Search Results"
 #search-results-main{"data-role" => "content", "data-theme" => "b"}
   %ul{"data-role" => "listview"}
     - @meetings.each do |group|
@@ -17,3 +15,4 @@
               - else
                 %li= meeting_without_distance(meeting)
               = render "meeting_detail", meeting: meeting
+= render "footer"

--- a/app/views/mobile/search/new.html.haml
+++ b/app/views/mobile/search/new.html.haml
@@ -1,6 +1,5 @@
 %div{"data-position" => "fixed", "data-role" => "header", "data-tap-toggle" => "false", "data-theme" => "b"}
-  %a.ui-btn.ui-icon-home.ui-btn-icon-left{:href => root_path} Home
-  %h1 Find a Meeting
+  %h1 New Search
 %div{"data-role" => "content", "data-theme" => "b", :role => "main"}
   %button{ "class" => "meeting-search-hot-button", "data-role" => "button", "data-icon" => "arrow-r", "data-iconpos" => "right", "id" => "one-time" }
     = "Right Here Right Now"
@@ -14,3 +13,4 @@
       = render partial: "access"
       = render partial: "language"
     = button_to "Search", mobile_search_index_path, {:method => :post, :class => "meeting-search-button", "data-role" => "button", "data-icon" => "arrow-r", "data-iconpos" => "right", "data-ajax" => "false", "rel" => "external"}
+= render "footer"

--- a/spec/features/search_from_landing_spec.rb
+++ b/spec/features/search_from_landing_spec.rb
@@ -9,13 +9,5 @@ RSpec.feature "Search from landing" do
       click_link_or_button "meetings-button"
       expect(current_path).to eq(new_mobile_search_path)
     end
-
-    scenario "it can view all listings" do
-      visit root_path
-      click_link_or_button "meetings-button"
-      expect(page).to have_content("Find a Meeting")
-      click_link_or_button "Search"
-      expect(page).to have_content("Tuesday")
-    end
   end
 end


### PR DESCRIPTION
Get rid of buttons on top. Get rid of meeting
count bubble. Change to new search on new search,
and search results on search index. Add little buttons
on the bottom to go back and for new searhc. Make
the buttons the same for both new search and on search
results, even though back and home have the same effect
from the new search screen.