### PR TITLE
ajaxify meeting searching

### DIFF
--- a/app/assets/javascripts/mobile/jquery_mobile_settings.js
+++ b/app/assets/javascripts/mobile/jquery_mobile_settings.js
@@ -2,6 +2,6 @@ $(document).on("mobileinit", function () {
     // Reference: http://jquerymobile.com/demos/1.1.0/docs/api/globalconfig.html
     $.extend($.mobile, {
         linkBindingEnabled: false,
-        ajaxEnabled: false
+        ajaxEnabled: true
     });
 });

--- a/app/controllers/mobile/search_controller.rb
+++ b/app/controllers/mobile/search_controller.rb
@@ -5,15 +5,13 @@ class Mobile::SearchController < ApplicationController
     @options = SearchOptions.new
   end
 
-  def index
-    search = Search.find(session[:search]) if session[:search]
-    @meetings = search.results
-  end
-
   def create
-    @search = Search.create(search_params)
-    session[:search] = @search.id
-    redirect_to mobile_search_index_path
+    search = Search.create(search_params)
+    @meetings = search.results
+
+    respond_to do |format|
+      format.js { render 'index' }
+    end
   end
 
   private

--- a/app/views/layouts/mobile.html.haml
+++ b/app/views/layouts/mobile.html.haml
@@ -7,5 +7,5 @@
     = javascript_include_tag 'mobile/mobile', media: 'all'
     = csrf_meta_tags
   %body
-    #p1{"data-role" => "page"}
+    #p1{"data-role" => "page", "data-theme" => "b"}
       = yield

--- a/app/views/mobile/search/_footer.html.haml
+++ b/app/views/mobile/search/_footer.html.haml
@@ -1,4 +1,4 @@
-%footer{ 'data-role' => "footer", 'data-theme' => "b", 'style' => "text-align:center;", "data-tap-toggle" => "true" }
+%footer{ 'data-role' => "footer", 'data-theme' => "b", 'style' => "text-align:center;", 'data-position' => 'fixed'}
   %div{ 'data-role' => "controlgroup", 'data-type' => "horizontal" }
     = link_to "Back", :back, { class: "ui-btn ui-corner-all ui-shadow ui-icon-arrow-l ui-btn-icon-notext" }
     = link_to "New", new_mobile_search_path, { class: "ui-btn ui-corner-all ui-shadow ui-icon-back ui-btn-icon-notext" }

--- a/app/views/mobile/search/_index.html.haml
+++ b/app/views/mobile/search/_index.html.haml
@@ -1,8 +1,8 @@
-%div{"data-role" => "header", "data-theme" => "b"}
+%div{"data-role" => "header"}
   %h1
     = "Search Results"
-#search-results-main{"data-role" => "content", "data-theme" => "b"}
-  %ul{"data-role" => "listview"}
+#search-results-main{"data-role" => "content"}
+  %ul{"data-role" => "listview", "id" => "meeting-list"}
     - @meetings.each do |group|
       - if !group.last.empty?
         %li{"data-role" => "list-divider"}= group.first
@@ -16,3 +16,6 @@
                 %li= meeting_without_distance(meeting)
               = render "meeting_detail", meeting: meeting
 = render "footer"
+
+:javascript
+  history.pushState("searched", "Search Results", "results");

--- a/app/views/mobile/search/index.js.haml
+++ b/app/views/mobile/search/index.js.haml
@@ -1,0 +1,2 @@
+:plain
+  $('#p1').html("#{j render 'index.html.haml'}").enhanceWithin();

--- a/app/views/mobile/search/new.html.haml
+++ b/app/views/mobile/search/new.html.haml
@@ -1,9 +1,9 @@
-%div{"data-position" => "fixed", "data-role" => "header", "data-tap-toggle" => "false", "data-theme" => "b"}
+%div{"data-position" => "fixed", "data-role" => "header", "data-tap-toggle" => "false"}
   %h1 New Search
-%div{"data-role" => "content", "data-theme" => "b", :role => "main"}
+%div{"data-role" => "content", :role => "main"}
   %button{ "class" => "meeting-search-hot-button", "data-role" => "button", "data-icon" => "arrow-r", "data-iconpos" => "right", "id" => "one-time" }
     = "Right Here Right Now"
-  = form_tag(controller: "mobile/search", action: "create", method: "post", "data-ajax" => "false") do
+  = form_tag(mobile_search_index_path, method: :post, remote: true) do
     - cache(cache_key_for(Meeting, "search-menu")) do
       = render partial: "location"
       = render partial: "day_time"
@@ -12,5 +12,8 @@
       = render partial: "special_focus"
       = render partial: "access"
       = render partial: "language"
-    = button_to "Search", mobile_search_index_path, {:method => :post, :class => "meeting-search-button", "data-role" => "button", "data-icon" => "arrow-r", "data-iconpos" => "right", "data-ajax" => "false", "rel" => "external"}
+    = button_to "Search", mobile_search_index_path, {:method => :post, :class => "meeting-search-button", "data-role" => "button", "data-icon" => "arrow-r", "data-iconpos" => "right", "rel" => "external"}
 = render "footer"
+
+:javascript
+  history.pushState("new_search", "New Search", "new");

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,9 +10,14 @@ Rails.application.routes.draw do
   get "auth/github/callback", to: "sessions#create"
 
   namespace :mobile do
-    resources :search, only:[:new, :create, :index]
+    resources :search, only:[:new, :create, :index] do
+      get 'results', on: :collection, to: "search#new"
+    end
+
+    # are these used?
     get "search/create", to: "search#create"
     resources :meetings, only:[:index, :show]
+    ####
   end
 
   namespace :admin do


### PR DESCRIPTION
- remove global ajax:false setting from jqm init (not
sure this really did anything but it didn't hurt..
note that the other setting about link binding did
hurt when it was turned off.. it caused sytling to be
wiped when following links back to home and such)
- configure search form for data remote
- rework controller to give js response.. this enabled
cleanup so that no redirection to another action was
happening, which took away need for writing a search id
to the session which was done because of object hijacking
- had problems with the j rendered partial then missing some
of the jqm styling. this was most easily fixed by applying
the data theme to the single page we're using, which does
not change on ajax replace. TODO would be to see about this
page swapping business with jqm.. return a page, use some
function to change it out, do some animations, what have you.
- added javascript url-ing to change the url to -results-
- added a route so that refresh on this made up url would
take back to a new search. that necessitated bringing in
birds to bring in the spiders that were brought in to eat
the beatles.. no wait it just necessitated changing the url
of the new search as well so it wouldn't still say results
on a refresh in that manner

Summary: still fighting with jqm, but using ajax feels like i'm making friends with it, at least a little. But alas, when I started this project, ajax was a foreign and frightening thing.