### PR TITLE
Add server side google maps API key #141

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,8 @@ I got my feet wet with geolocating and jQuery in this project, as well as applyi
 There are many different types of people who would benefit from an application like this.. There are those who have been sober many years but are unfamiliar with the area. There are those who are still drinking who want to see if there might be another way. But in the design exercise, I decided to create it for a woman in the first three months of her sobriety.
 
 My user is a professional who is very good at her job when she shows up to it. The picture I drew of her for the design exercise showed her dressed up for work slumped on a bench at a bus stop. She's coming home early, because she got fired. A month or two of sobriety wasn't enough to reverse a cycle that was already in motion. She knows full well that a drink won't help the situation, but wants one anyway. She knows that a meeting might help and they're starting to become habit. Her phone is in her hand in the picture, and I hope my application helps make her day a bit brighter.
+
+#### Building
+
+API Keys. You're going to need some. Get a google maps API key for client-side and server-side. You can make use of Figaro to set the environment variables referenced by the app-- change sample_application.yml to application.yml and follow instructions in Figaro docs to set environment variables
+from the file in production. Do not check application.yml into a public repo.

--- a/app/views/mobile/search/new.html.haml
+++ b/app/views/mobile/search/new.html.haml
@@ -22,7 +22,7 @@
 
 :javascript
   function googleMapsKey(){
-    var key = "#{ENV['google_maps']}";
+    var key = "#{ENV['google_api_key_client']}";
     return key;
   }
 

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,1 +1,2 @@
 Geocoder.configure(timeout: 30)
+Geocoder.configure(api_key: ENV["google_api_key_server"])

--- a/config/sample_application.yml
+++ b/config/sample_application.yml
@@ -1,0 +1,20 @@
+# To use, change name to application.yml and populate
+# with your keys. Do not check into your repo. Lock
+# the keys down to your domain, especially the client
+# key, as it will be sent in client-side javascript.
+#
+# The local app should pick these up on their own thanks
+# to Figaro. Refre to the docs for how to use with Heroku,
+# etc. Or just rip out Figaro and use environment variables
+# by themselves or some other solution.
+#
+# google_api_key_server: "some_key"
+# google_api_key_client: "another_key"
+
+# development:
+#   google_api_key_server: "some_key"
+#   google_api_key_client: "another_key"
+
+# test:
+#   google_api_key_server: "some_key"
+#   google_api_key_client: "another_key"


### PR DESCRIPTION
Also, rename client key. Organize both in hidden application.yml for
use by Figaro.

May solve the issue with geocoding over the limit errors for very low numbers of geocode requests.