### PR TITLE
Fix meetings with close parens

### DIFF
--- a/app/models/raw_meeting.rb
+++ b/app/models/raw_meeting.rb
@@ -13,21 +13,19 @@ class RawMeeting < ActiveRecord::Base
   end
 
   def self.add_from(raw)
-    checksum = compute_checksum(raw)
-    self.where(checksum: checksum)
-        .first_or_create(
-          {day: raw[0],
-          time: raw[1],
-          group_name: raw[2],
-          address: raw[3],
-          city: raw[4],
-          district: raw[5],
-          codes: raw[6]})
+    self.where(
+      day: raw[0],
+      time: raw[1],
+      group_name: raw[2],
+      address: raw[3],
+      city: raw[4],
+      district: raw[5],
+      codes: raw[6]
+    ).first_or_create
   end
 
   def self.for_all_non_daccaa_deleted
-    ids = Meeting.joins(:raw_meeting).where(deleted: false).pluck(:raw_meeting_id)
-    self.where(id: ids)
+    RawMeeting.joins(:meeting).where('meetings.deleted' => false)
   end
 
   def self.raw_from_yaml(file)
@@ -38,14 +36,5 @@ class RawMeeting < ActiveRecord::Base
     raw_from_yaml(file).map do |data|
       add_from(data.values)
     end
-  end
-
-  def self.meeting_unique?(raw)
-    checksum = compute_checksum(raw)
-    RawMeeting.exists?(checksum: checksum) ? false : checksum
-  end
-
-  def self.compute_checksum(raw)
-    Digest::SHA1.hexdigest(raw.join)
   end
 end

--- a/db/migrate/20190128050704_readd_nil_address1_meetings.rb
+++ b/db/migrate/20190128050704_readd_nil_address1_meetings.rb
@@ -1,0 +1,13 @@
+class ReaddNilAddress1Meetings < ActiveRecord::Migration[5.2]
+  def change
+    raw_meeting_addresses = RawMeeting.pluck(:address).select{ |name| name.match /\S\(/ }
+    raw_meetings = RawMeeting.where(address: raw_meeting_addresses)
+    meetings = Meeting.where(raw_meeting: raw_meetings)
+
+    Rails.logger.info { "About to delete meetings: #{meetings}" }
+    meetings.destroy_all
+
+    Rails.logger.info { "About to delete raw_meetings: #{raw_meetings}" }
+    raw_meetings.destroy_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2016_10_01_195456) do
+ActiveRecord::Schema.define(version: 2019_01_28_050704) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"

--- a/spec/models/raw_meeting_spec.rb
+++ b/spec/models/raw_meeting_spec.rb
@@ -17,25 +17,6 @@ RSpec.describe RawMeeting do
     @raw_stream = @raw_attributes.values
   end
 
-  context "#self.compute_checksum" do
-    it "computes checksum based on all raw values" do
-      #Meeting name is not guaranteed to be unique. Meeting name and location
-      # are not unique as some meeting are throughout the week. Check uniqueness
-      # from all values with a checksum
-      checksum = RawMeeting.compute_checksum(@raw_stream)
-
-      expect(checksum.is_a?(String)).to be_truthy
-      expect(checksum.empty?).to be_falsey
-    end
-
-    it "computes the same checksum for the same meeting" do
-      checksum = RawMeeting.compute_checksum(@raw_stream)
-      recalc = RawMeeting.compute_checksum(@raw_stream)
-
-      expect(checksum).to eq(recalc)
-    end
-  end
-
   context "Using #self.add_from" do
     before(:each) do
       RawMeeting.add_from(@raw_stream)


### PR DESCRIPTION
Still dealing with fallout from the bad strip command.. And this probably
won't finish it.. But it will kill the meetings that have a raw meeting
with an address that includes a non-whitespace character followed immediately
by an open paren, then it will kill their raw meetings, and since the
raw parser has been fixed, they will be created correctly.

But what else is wrong with the syncing? Not sure.