### PR TITLE
Reorganize format, feature, and other attribute builders

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -369,3 +369,9 @@ DEPENDENCIES
   vcr
   web-console (~> 2.0)
   webmock
+
+RUBY VERSION
+   ruby 2.3.0p0
+
+BUNDLED WITH
+   1.17.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -369,9 +369,3 @@ DEPENDENCIES
   vcr
   web-console (~> 2.0)
   webmock
-
-RUBY VERSION
-   ruby 2.3.0p0
-
-BUNDLED WITH
-   1.17.1

--- a/app/models/meeting_creator.rb
+++ b/app/models/meeting_creator.rb
@@ -69,11 +69,19 @@ class MeetingCreator
   end
 
   def address_1
-    raw.address.gsub(raw_notes, "").gsub(raw_phone, "").strip
+    raw.address.gsub(raw_notes, "")
+               .gsub(raw_phone, "")
+               .gsub(raw_unit, "")
+               .strip
   end
 
   def address_2
-    #logic here
+    remove_leading_comma(raw_unit)
+  end
+
+  def raw_unit
+    unit_match = raw.address.match(/(, )?(unit).{0,1}\d+/i)
+    unit_match ? unit_match[0] : ""
   end
 
   def raw_phone

--- a/app/models/meeting_creator.rb
+++ b/app/models/meeting_creator.rb
@@ -15,7 +15,8 @@ class MeetingCreator
   end
 
   def base_attributes
-    { group_name: group_name,
+    {
+      group_name: group_name,
       day: day,
       address_1: address_1,
       notes: notes,
@@ -24,7 +25,8 @@ class MeetingCreator
       state: "CO",
       closed: closed,
       time: time,
-      raw_meeting: self.raw }
+      raw_meeting: self.raw
+    }
   end
 
   def format_attributes
@@ -103,10 +105,12 @@ class MeetingCreator
   end
 
   def properties_models
-    {Focus => "foci",
-    Format => "formats",
-    Feature => "features",
-    Language => "languages"}
+    {
+      MeetingCreator::Focus => "foci",
+      MeetingCreator::Format => "formats",
+      MeetingCreator::Feature => "features",
+      MeetingCreator::Language => "languages"
+    }
   end
 
   def self.features_classes
@@ -116,5 +120,4 @@ class MeetingCreator
   def get_property_set_for(codes, property)
     property.first.send("get_#{property.last}".to_sym, (codes))
   end
-
 end

--- a/app/models/meeting_creator/feature.rb
+++ b/app/models/meeting_creator/feature.rb
@@ -1,5 +1,4 @@
-class Feature
-  
+class MeetingCreator::Feature
   def self.is_asl?(codes)
     codes =~ /.*ASL.*/
   end

--- a/app/models/meeting_creator/focus.rb
+++ b/app/models/meeting_creator/focus.rb
@@ -1,5 +1,4 @@
-class Focus
-
+class MeetingCreator::Focus
   def self.get_men
     self.find_or_create_by(code: "M") do |focus|
       focus.name = "Men"
@@ -31,5 +30,4 @@ class Focus
   def self.focus_methods
     [:men, :women, :gay, :young_people]
   end
-
 end

--- a/app/models/meeting_creator/format.rb
+++ b/app/models/meeting_creator/format.rb
@@ -1,4 +1,4 @@
-class Format
+class MeetingCreator::Format
   def self.is_speaker?(codes)
     codes.include?("SP")
   end
@@ -37,5 +37,4 @@ class Format
     [:speaker, :step, :big_book, :grapevine,
       :traditions, :candlelight, :beginners]
   end
-
 end

--- a/app/models/meeting_creator/language.rb
+++ b/app/models/meeting_creator/language.rb
@@ -1,4 +1,4 @@
-class Language
+class MeetingCreator::Language
   def self.get_languages(codes)
     permitted_languages.each_with_object({}) do |(code, language), results|
       results[language] = codes.include? code

--- a/app/models/meeting_feature.rb
+++ b/app/models/meeting_feature.rb
@@ -1,4 +1,0 @@
-class MeetingFeature < ActiveRecord::Base
-  belongs_to :meeting
-  belongs_to :feature
-end

--- a/app/models/meeting_focus.rb
+++ b/app/models/meeting_focus.rb
@@ -1,4 +1,0 @@
-class MeetingFocus < ActiveRecord::Base
-  belongs_to :meeting
-  belongs_to :focus
-end

--- a/app/models/meeting_format.rb
+++ b/app/models/meeting_format.rb
@@ -1,4 +1,0 @@
-class MeetingFormat < ActiveRecord::Base
-  belongs_to :meeting
-  belongs_to :format
-end

--- a/app/models/meeting_language.rb
+++ b/app/models/meeting_language.rb
@@ -1,4 +1,0 @@
-class MeetingLanguage < ActiveRecord::Base
-  belongs_to :meeting
-  belongs_to :language
-end

--- a/app/models/search_options.rb
+++ b/app/models/search_options.rb
@@ -114,7 +114,7 @@ class SearchOptions
 
   def foci
     @foci ||= begin
-      Focus.focus_methods.select do |focus|
+      MeetingCreator::Focus.focus_methods.select do |focus|
         self.meetings.where(focus => true).exists?
       end.map { |f| f.to_s.titleize }
     end
@@ -122,7 +122,7 @@ class SearchOptions
 
   def languages
     @languages ||= begin
-      Language.language_methods.select do |lang|
+      MeetingCreator::Language.language_methods.select do |lang|
         self.meetings.where(lang => true).exists?
       end.map { |f| f.to_s.titleize }
     end
@@ -130,7 +130,7 @@ class SearchOptions
 
   def formats
     @formats ||= begin
-      Format.format_methods.select do |format|
+      MeetingCreator::Format.format_methods.select do |format|
         self.meetings.where(format => true).exists?
       end.map { |f| f.to_s.titleize }
     end
@@ -138,7 +138,7 @@ class SearchOptions
 
   def features
     @features ||= begin
-      Feature.feature_methods.select do |feature|
+      MeetingCreator::Feature.feature_methods.select do |feature|
         self.meetings.where(feature => true).exists?
       end.map { |f| f.to_s.titleize }
     end

--- a/app/models/search_options.rb
+++ b/app/models/search_options.rb
@@ -42,17 +42,15 @@ class SearchOptions
   end
 
   def open?
-    @open ||= self.meetings.where(closed: [false, nil]).exists?
+    self.meetings.where(closed: [false, nil]).exists?
   end
 
   def closed?
-    @closed ||= self.meetings.where(closed: true).exists?
+    self.meetings.where(closed: true).exists?
   end
 
   def cities_found
-    @cities_found ||= begin
-      self.meetings.pluck(:city).uniq.sort
-    end
+    self.meetings.pluck(:city).uniq.sort
   end
 
   def cities_json
@@ -60,21 +58,17 @@ class SearchOptions
   end
 
   def cities
-    @cities ||= begin
-      any = ["City", "any"]
-      self.cities_found.prepend(any)
-    end
+    any = ["City", "any"]
+    self.cities_found.prepend(any)
   end
 
   def times_found_raw
-    @times_found_raw ||= self.meetings.pluck(:time).uniq.sort
+    self.meetings.pluck(:time).uniq.sort
   end
 
   def times_found
-    @times_found ||= begin
-      times_found_raw.map { |t| TimeConverter.display(t) }
-      .zip(times_found_raw)
-    end
+    times_found_raw.map { |t| TimeConverter.display(t) }
+                   .zip(times_found_raw)
   end
 
   def self.display_range_to_raw
@@ -139,7 +133,7 @@ class SearchOptions
 
   def formats
     format_methods.select do |format|
-        self.meetings.where(format => true).exists?
+      self.meetings.where(format => true).exists?
     end.map { |f| f.to_s.titleize }
   end
 
@@ -154,17 +148,15 @@ class SearchOptions
   end
 
   def times
-    @times ||= [any_time_range, now_time_range] + time_ranges + times_found
+    [any_time_range, now_time_range] + time_ranges + times_found
   end
 
   def meeting_names
-    @names ||= self.meetings.pluck(:group_name).uniq.sort
+    self.meetings.pluck(:group_name).uniq.sort
   end
 
   def meetings_json
-    @meetings_json ||= begin
-      ["any"] + self.meetings.pluck(:group_name).uniq.sort
-    end
+    ["any"] + self.meetings.pluck(:group_name).uniq.sort
   end
 
   def names_select
@@ -173,11 +165,11 @@ class SearchOptions
   end
 
   def days_found
-    @days_found ||= self.meetings.pluck(:day).uniq
+    self.meetings.pluck(:day).uniq
   end
 
   def days_found_sorted
-    @days_found_sorted ||= Day.day_order.keep_if { |day| days_found.include? day }
+    Day.day_order.keep_if { |day| days_found.include? day }
   end
 
   def today_included?
@@ -189,11 +181,9 @@ class SearchOptions
   end
 
   def days
-    @days ||= begin
-      any = ["Day", "any"]
-      today = ["Today (#{self.today})", "#{self.today}"] if self.today_included?
-      days_found_sorted.zip(days_found_sorted).prepend(any, today)
-    end
+    any = ["Day", "any"]
+    today = ["Today (#{self.today})", "#{self.today}"] if self.today_included?
+    days_found_sorted.zip(days_found_sorted).prepend(any, today)
   end
 
 end

--- a/app/models/search_options.rb
+++ b/app/models/search_options.rb
@@ -112,36 +112,45 @@ class SearchOptions
     end
   end
 
+  def focus_methods
+    [:men, :women, :gay, :young_people]
+  end
+
   def foci
-    @foci ||= begin
-      MeetingCreator::Focus.focus_methods.select do |focus|
-        self.meetings.where(focus => true).exists?
-      end.map { |f| f.to_s.titleize }
-    end
+    focus_methods.select do |focus|
+      self.meetings.where(focus => true).exists?
+    end.map { |f| f.to_s.titleize }
+  end
+
+  def language_methods
+    [:spanish, :french, :polish]
   end
 
   def languages
-    @languages ||= begin
-      MeetingCreator::Language.language_methods.select do |lang|
-        self.meetings.where(lang => true).exists?
-      end.map { |f| f.to_s.titleize }
-    end
+    language_methods.select do |lang|
+      self.meetings.where(lang => true).exists?
+    end.map { |f| f.to_s.titleize }
+  end
+
+  def format_methods
+    [:speaker, :step, :big_book, :grapevine,
+      :traditions, :candlelight, :beginners]
   end
 
   def formats
-    @formats ||= begin
-      MeetingCreator::Format.format_methods.select do |format|
+    format_methods.select do |format|
         self.meetings.where(format => true).exists?
-      end.map { |f| f.to_s.titleize }
-    end
+    end.map { |f| f.to_s.titleize }
+  end
+
+  def feature_methods
+    [:asl, :accessible, :non_smoking, :sitter]
   end
 
   def features
-    @features ||= begin
-      MeetingCreator::Feature.feature_methods.select do |feature|
-        self.meetings.where(feature => true).exists?
-      end.map { |f| f.to_s.titleize }
-    end
+    feature_methods.select do |feature|
+      self.meetings.where(feature => true).exists?
+    end.map { |f| f.to_s.titleize }
   end
 
   def times

--- a/spec/models/meeting_creator/feature_spec.rb
+++ b/spec/models/meeting_creator/feature_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-RSpec.describe Feature, type: :model do
+RSpec.describe MeetingCreator::Feature, type: :model do
   include_context "codes"
 
   it "has all the features" do
 
     features = [:asl, :accessible, :non_smoking, :sitter]
 
-    found_features = Feature.get_features("")
+    found_features = described_class.get_features("")
 
     features.each do |feature|
       expect(found_features.include? feature).to be_truthy
@@ -18,7 +18,7 @@ RSpec.describe Feature, type: :model do
 
     it "finds ASL" do
       raw_code = "ASL"
-      features = Feature.get_features(raw_code)
+      features = described_class.get_features(raw_code)
 
       expect(features.delete :asl).to be_truthy
       expect(features.values.reduce(&:|)).to be_falsey
@@ -26,7 +26,7 @@ RSpec.describe Feature, type: :model do
 
     it "finds accessible" do
       raw_code = "*nFrnSp"
-      features = Feature.get_features(raw_code)
+      features = described_class.get_features(raw_code)
 
       expect(features.delete(:accessible)).to be_truthy
       expect(features.delete(:non_smoking)).to be_truthy
@@ -36,7 +36,7 @@ RSpec.describe Feature, type: :model do
 
     it "finds non-smoking" do
       raw_code = "n"
-      features = Feature.get_features(raw_code)
+      features = described_class.get_features(raw_code)
 
       expect(features.delete :non_smoking).to be_truthy
       expect(features.values.reduce(&:|)).to be_falsey
@@ -44,7 +44,7 @@ RSpec.describe Feature, type: :model do
 
     it "does not give non-smoking false positive with Spn" do
       raw_code = "Spn"
-      features = Feature.get_features(raw_code)
+      features = described_class.get_features(raw_code)
 
       expect(features.delete :non_smoking).to be_falsey
       expect(features.values.reduce(&:|)).to be_falsey
@@ -52,7 +52,7 @@ RSpec.describe Feature, type: :model do
 
     it "does not give non-smoking false positive with Frn" do
       raw_code = "Frn"
-      features = Feature.get_features(raw_code)
+      features = described_class.get_features(raw_code)
 
       expect(features.delete :non_smoking).to be_falsey
       expect(features.values.reduce(&:|)).to be_falsey
@@ -60,7 +60,7 @@ RSpec.describe Feature, type: :model do
 
     it "finds sitter" do
       raw_code = "Sit"
-      features = Feature.get_features(raw_code)
+      features = described_class.get_features(raw_code)
 
       expect(features.delete :sitter).to be_truthy
       expect(features.values.reduce(&:|)).to be_falsey
@@ -68,7 +68,7 @@ RSpec.describe Feature, type: :model do
 
     it "finds with other codes" do
       raw_code = "*nFrnSp"
-      features = Feature.get_features(raw_code)
+      features = described_class.get_features(raw_code)
 
       expect(features.delete :accessible).to be_truthy
       expect(features.delete :non_smoking).to be_truthy

--- a/spec/models/meeting_creator/focus_spec.rb
+++ b/spec/models/meeting_creator/focus_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-RSpec.describe Focus, type: :model do
+RSpec.describe MeetingCreator::Focus, type: :model do
   include_context "codes"
 
   it "gives result for each foci" do
     needed_foci = [:men, :women, :gay, :young_people]
     raw_code = ""
 
-    foci = Focus.get_foci(raw_code)
+    foci = described_class.get_foci(raw_code)
 
     needed_foci.each do |focus|
       expect(foci.include? focus).to be_truthy
@@ -18,7 +18,7 @@ RSpec.describe Focus, type: :model do
 
     it "finds men" do
       raw_code = "M"
-      foci = Focus.get_foci(raw_code)
+      foci = described_class.get_foci(raw_code)
 
       expect(foci[:men]).to be_truthy
 
@@ -28,7 +28,7 @@ RSpec.describe Focus, type: :model do
 
     it "finds women" do
       raw_code = "W"
-      foci = Focus.get_foci(raw_code)
+      foci = described_class.get_foci(raw_code)
 
       expect(foci[:women]).to be_truthy
 
@@ -38,7 +38,7 @@ RSpec.describe Focus, type: :model do
 
     it "finds gay" do
       raw_code = "G"
-      foci = Focus.get_foci(raw_code)
+      foci = described_class.get_foci(raw_code)
 
       expect(foci[:gay]).to be_truthy
 
@@ -48,14 +48,14 @@ RSpec.describe Focus, type: :model do
 
     it "does not give gay false positive with GV" do
       raw_code = "GV"
-      foci = Focus.get_foci(raw_code)
+      foci = described_class.get_foci(raw_code)
 
       expect(foci.values.any? { |x| x == true }).to be_falsey
     end
 
     it "finds young people" do
       raw_code = "Y"
-      foci = Focus.get_foci(raw_code)
+      foci = described_class.get_foci(raw_code)
 
       expect(foci[:young_people]).to be_truthy
 

--- a/spec/models/meeting_creator/format_spec.rb
+++ b/spec/models/meeting_creator/format_spec.rb
@@ -1,20 +1,21 @@
 require 'rails_helper'
 
-RSpec.describe Format, type: :model do
+RSpec.describe MeetingCreator::Format, type: :model do
   include_context "codes"
 
   it "has all formats" do
     format = [:speaker, :step, :big_book, :grapevine,
       :traditions, :candlelight, :beginners]
-    found_formats = Format.get_formats("")
+    found_formats = described_class.get_formats("")
 
     format.each do |format|
       expect(found_formats.keys.include? format).to be_truthy
     end
   end
+
   it "finds grapevine" do
     raw_code = "GV"
-    formats = Format.get_formats(raw_code)
+    formats = described_class.get_formats(raw_code)
 
     expect(formats[:grapevine]).to be_truthy
     formats.delete :grapevine
@@ -23,14 +24,14 @@ RSpec.describe Format, type: :model do
 
   it "does not give beginner false positive with BB" do
     raw_code = "BB"
-    formats = Format.get_formats(raw_code)
+    formats = described_class.get_formats(raw_code)
 
     expect(formats[:beginner]).to be_falsey
   end
 
   it "finds traditions" do
     raw_code = "T"
-    formats = Format.get_formats(raw_code)
+    formats = described_class.get_formats(raw_code)
 
     expect(formats[:traditions]).to be_truthy
     formats.delete :traditions
@@ -39,7 +40,7 @@ RSpec.describe Format, type: :model do
 
   it "does not find traditions in ST" do
     raw_code = "ST"
-    formats = Format.get_formats(raw_code)
+    formats = described_class.get_formats(raw_code)
 
     expect(formats[:step]).to be_truthy
     formats.delete :step
@@ -48,7 +49,7 @@ RSpec.describe Format, type: :model do
 
   it "finds with other codes" do
     raw_code = "BBBSTTC"
-    formats = Format.get_formats(raw_code)
+    formats = described_class.get_formats(raw_code)
 
     expected_names = [:big_book, :beginners, :step, :traditions]
 

--- a/spec/models/meeting_creator/language_spec.rb
+++ b/spec/models/meeting_creator/language_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
-RSpec.describe Language, type: :model do
+RSpec.describe MeetingCreator::Language, type: :model do
   include_context "codes"
 
   it "has all the languages" do
     languages = [:french, :polish, :spanish]
 
-    found_languages = Language.get_languages ""
+    found_languages = described_class.get_languages ""
 
     languages.each do |language|
       expect(found_languages.keys.include? language).to be_truthy
@@ -14,10 +14,9 @@ RSpec.describe Language, type: :model do
   end
 
   context "parses from aggregate code" do
-
     it "finds french" do
       raw_code = "Frn"
-      languages = Language.get_languages(raw_code)
+      languages = described_class.get_languages(raw_code)
 
       expect(languages.delete(:french)).to be_truthy
       expect(languages.values.reduce(&:|)).to be_falsey
@@ -25,7 +24,7 @@ RSpec.describe Language, type: :model do
 
     it "finds spanish" do
       raw_code = "Spn"
-      languages = Language.get_languages(raw_code)
+      languages = described_class.get_languages(raw_code)
 
       expect(languages.delete(:spanish)).to be_truthy
       expect(languages.values.reduce(&:|)).to be_falsey
@@ -33,7 +32,7 @@ RSpec.describe Language, type: :model do
 
     it "finds polish" do
       raw_code = "Pol"
-      languages = Language.get_languages(raw_code)
+      languages = described_class.get_languages(raw_code)
 
       expect(languages.delete(:polish)).to be_truthy
       expect(languages.values.reduce(&:|)).to be_falsey
@@ -41,11 +40,10 @@ RSpec.describe Language, type: :model do
 
     it "finds with other codes" do
       raw_code = "*nFrnSp"
-      languages = Language.get_languages(raw_code)
+      languages = described_class.get_languages(raw_code)
 
       expect(languages.delete(:french)).to be_truthy
       expect(languages.values.reduce(&:|)).to be_falsey
     end
-
   end
 end

--- a/spec/models/meeting_creator_spec.rb
+++ b/spec/models/meeting_creator_spec.rb
@@ -65,7 +65,11 @@ RSpec.describe MeetingCreator do
     end
 
     it "parses address_1" do
-      expect(@mc.address_1).to eql("8250 W. 80th Ave. Unit 12")
+      expect(@mc.address_1).to eql("8250 W. 80th Ave.")
+    end
+
+    it "parses address_2" do
+      expect(@mc.address_2).to eql("Unit 12")
     end
 
     it "parses notes" do
@@ -109,7 +113,11 @@ RSpec.describe MeetingCreator do
     end
 
     it "parses address_1" do
-      expect(@mc.address_1).to eql("15210 E 6th Ave, Unit 1")
+      expect(@mc.address_1).to eql("15210 E 6th Ave")
+    end
+
+    it "parses address_2" do
+      expect(@mc.address_2).to eql("Unit 1")
     end
 
     it "parses notes" do

--- a/spec/models/meeting_creator_spec.rb
+++ b/spec/models/meeting_creator_spec.rb
@@ -53,6 +53,11 @@ RSpec.describe MeetingCreator do
     it "parses notes" do
       expect(@mc.notes).to eql("Ch bsmt #104")
     end
+
+    it "is men's" do
+      expect(@mc.build_attributes[:men]).to be_truthy
+      expect(@mc.build_attributes[:gay]).to be_falsey
+    end
   end
 
   context "with phone number" do


### PR DESCRIPTION
Format, feature et al used to be separate models/tables. Then, boolean attributes were created for meetings, and the tables were gotten rid of. There are still various helper files for parsing meeting data, and those same files were accessed by SearchOptions, which provides json to the front end to build and update the menu.

This PR represents the first step in reorganization. It does this:
- Removes references from the menu builder (SearchOptions) to the parsing helpers
- It reorganizes the parsing helpers in the app/models/meeting folder
- Cleans up SearchOptions
    - rubocop cleanup
    - First iteration of query cleanup `.distinct.pluck(:value)` instead of `.pluck(:value).uniq` taking advantage of Rails 5 AR
- Removes the dead models for feature, format, etc.
