### PR TITLE
Add new build_attributes flow for meeting_creator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: ruby
 rvm:
 - 2.3.0
+services:
+- postgresql
+before_script:
+- cp ./config/travis.database.yml ./config/database.yml
+- psql -c 'create database travis_ci_test;' -U postgres
 script:
 - bundle install
-- bundle exec rake db:create db:schema:load
+- bundle exec rake db:setup
 - bundle exec rspec spec
 deploy:
   provider: heroku

--- a/Gemfile
+++ b/Gemfile
@@ -56,4 +56,3 @@ end
 group :development do
   gem 'web-console', '~> 2.0'
 end
-

--- a/app/controllers/mobile/search_controller.rb
+++ b/app/controllers/mobile/search_controller.rb
@@ -22,7 +22,7 @@ class Mobile::SearchController < ApplicationController
     @options = SearchOptions.new(meetings: search.raw_meetings,
                                    source: params[:source])
     respond_to do |format|
-      format.json { render :json => @options }
+      format.json { render json: @options }
     end
   end
 

--- a/app/models/meeting/extract_phone.rb
+++ b/app/models/meeting/extract_phone.rb
@@ -1,4 +1,8 @@
-class ExtractPhone
+# This was put in place in early 2019 to scrube phone numbers out of existing
+# addresses. That is, it gets the phone number, saves it where it should be,
+# removes the number and any leading comma from the address, and stores the
+# address.
+class Meeting::ExtractPhone
   class << self
     def extract! meeting
       initial_address = meeting.address_1
@@ -16,7 +20,7 @@ class ExtractPhone
     end
 
     def phone_regex
-      /\d{3}(-\d{3})?-\d{4}/
+      MeetingCreator::PhoneExtractor.phone_matcher
     end
 
     def phone_and_leading_comma_regex

--- a/app/models/meeting_creator.rb
+++ b/app/models/meeting_creator.rb
@@ -1,6 +1,10 @@
+# Use to create a Meeting from a RawMeeting
+# - Initialize with a RawMeeting
+# - Call `.create` on the returned object to create the Meeting
 class MeetingCreator
   attr_reader :raw
 
+  # raw is a RawMeeting
   def initialize(raw)
     @raw = raw
   end
@@ -11,113 +15,6 @@ class MeetingCreator
   end
 
   def build_attributes
-    base_attributes.merge(format_attributes)
-  end
-
-  def base_attributes
-    {
-      group_name: group_name,
-      day: day,
-      address_1: address_1,
-      notes: notes,
-      district: district,
-      city: city,
-      state: "CO",
-      closed: closed,
-      time: time,
-      raw_meeting: self.raw
-    }
-  end
-
-  def format_attributes
-    properties_models.inject({}) do |attributes, prop_set|
-      attributes.merge get_property_set_for(codes, prop_set.to_a)
-    end
-  end
-
-  def day
-    raw.day
-  end
-
-  def time
-    TimeConverter.to_dec(raw.time)
-  end
-
-  def closed
-    codes =~ /(.*C[^A].*)|(.*C$)/ ? true : false
-  end
-
-  def group_name
-    raw.group_name
-  end
-
-  def city
-    city ||= raw.city
-  end
-
-  def notes
-    notes ||= raw_notes.gsub(/[(|)]/, "")
-  end
-
-  def raw_notes
-    raw_notes ||= begin
-      notes_match = self.raw.address.match(/\(.+\)/)
-      notes_match ? notes_match.to_s : ""
-    end
-  end
-
-  def codes
-    raw.codes
-  end
-
-  def address_1
-    raw.address.gsub(raw_notes, "")
-               .gsub(raw_phone, "")
-               .gsub(raw_unit, "")
-               .strip
-  end
-
-  def address_2
-    remove_leading_comma(raw_unit)
-  end
-
-  def raw_unit
-    unit_match = raw.address.match(/(, )?(unit).{0,1}\d+/i)
-    unit_match ? unit_match[0] : ""
-  end
-
-  def raw_phone
-    phone_match = raw.address.match(/(, )?\d{3}(-\d{3})?-\d{4}/)
-    phone_match ? phone_match[0] : ""
-  end
-
-  def remove_leading_comma(raw_phone)
-    has_leading_comma = raw_phone.match(/^,( )?/)
-    has_leading_comma ? has_leading_comma.post_match : raw_phone
-  end
-
-  def phone
-    remove_leading_comma(raw_phone)
-  end
-
-  def district
-    raw.district
-  end
-
-  def properties_models
-    {
-      MeetingCreator::Focus => "foci",
-      MeetingCreator::Format => "formats",
-      MeetingCreator::Feature => "features",
-      MeetingCreator::Language => "languages"
-    }
-  end
-
-  def self.features_classes
-    @@features_classes ||= self.new(nil).properties_models.keys
-  end
-
-  def get_property_set_for(codes, property)
-    property.first.send("get_#{property.last}".to_sym, (codes))
+    MeetingCreator::BuildAttributes.build_from(raw)
   end
 end

--- a/app/models/meeting_creator/accessible_extractor.rb
+++ b/app/models/meeting_creator/accessible_extractor.rb
@@ -1,0 +1,5 @@
+class MeetingCreator::AccessibleExtractor
+  def self.extract(raw_meeting)
+    raw_meeting.codes =~ /.*\*.*/
+  end
+end

--- a/app/models/meeting_creator/address1_extractor.rb
+++ b/app/models/meeting_creator/address1_extractor.rb
@@ -1,0 +1,76 @@
+class MeetingCreator::Address1Extractor
+  def self.extract(raw_meeting)
+    address = raw_meeting.address
+
+    address = check_and_fix_clarkson(address)
+    address = check_and_fix_depew(address)
+
+    # next two are order dependent
+    address = check_and_fix_wadsworth_bl(address)
+    address = check_and_fix_wadsworth(address)
+
+    # notes needs to come before unit
+    address = keep_only_before_notes(address)
+    address = keep_only_before_unit(address)
+    address = keep_only_before_comma(address)
+    address = keep_only_before_phone(address)
+    address.strip
+  end
+
+  def self.check_and_fix_wadsworth_bl(address)
+    return address unless address.match(/Wadsworth Bl\./)
+
+    address.gsub(/Wadsworth Bl\./, 'Wadsworth Blvd.')
+  end
+
+  def self.check_and_fix_depew(address)
+    return address unless address.match(/Depew/) &&
+      !address.match(/Depew St/)
+
+    address.gsub(/Depew /, 'Depew St. ')
+  end
+
+  # clarkson is a street and needs to be that way to be geocoded, but is
+  # missing the suffix on daccaa.
+  def self.check_and_fix_clarkson(address)
+    return address unless address.match(/Clarkson/) &&
+      !address.match(/Clarkson St/)
+    address.gsub(/Clarkson /, 'Clarkson St. ')
+  end
+
+  def self.check_and_fix_wadsworth(address)
+    return address unless address.match(/Wadsworth/) &&
+      !address.match(/Wadsworth Blvd/)
+
+    address.gsub(/Wadsworth /, 'Wadsworth Blvd. ')
+  end
+
+  # any parenthetical notes like '8817 S. Broadway (Ch)'
+  def self.keep_only_before_notes(address)
+    matched = address.match(/\(.+\)/)
+    return address unless matched
+
+    matched.pre_match.strip
+  end
+
+  def self.keep_only_before_comma(address)
+    matched = address.match(/,/)
+    return address unless matched
+
+    matched.pre_match.strip
+  end
+
+  def self.keep_only_before_unit(address)
+    matched = address.match(/(Unit|Ste|#)/)
+    return address unless matched
+
+    matched.pre_match.strip
+  end
+
+  def self.keep_only_before_phone(address)
+    matched = address.match(/\d{3}(-\d{3})?-\d{4}/)
+    return address unless matched
+
+    matched.pre_match.strip
+  end
+end

--- a/app/models/meeting_creator/address2_extractor.rb
+++ b/app/models/meeting_creator/address2_extractor.rb
@@ -1,0 +1,17 @@
+class MeetingCreator::Address2Extractor
+  def self.extract(raw_meeting)
+    address = remove_notes(raw_meeting.address)
+    matched = address.match /(Unit|Ste|#)[\.]?[ ]{0,}[\w-]+/
+    return '' unless matched
+
+    matched.to_s
+  end
+
+  def self.remove_notes(address)
+    matcher = MeetingCreator::NotesExtractor.notes_matcher
+    matched = address.match(matcher)
+    return address unless matched
+
+    address.delete(matched.to_s)
+  end
+end

--- a/app/models/meeting_creator/asl_extractor.rb
+++ b/app/models/meeting_creator/asl_extractor.rb
@@ -1,0 +1,5 @@
+class MeetingCreator::AslExtractor
+  def self.extract(raw_meeting)
+    raw_meeting.codes =~ /.*ASL.*/
+  end
+end

--- a/app/models/meeting_creator/beginners_extractor.rb
+++ b/app/models/meeting_creator/beginners_extractor.rb
@@ -1,0 +1,6 @@
+class MeetingCreator::BeginnersExtractor
+  def self.extract(raw_meeting)
+    codes = raw_meeting.codes
+    codes.include?('B') && (codes.count('B') != 2)
+  end
+end

--- a/app/models/meeting_creator/big_book_extractor.rb
+++ b/app/models/meeting_creator/big_book_extractor.rb
@@ -1,0 +1,5 @@
+class MeetingCreator::BigBookExtractor
+  def self.extract(raw_meeting)
+    raw_meeting.codes.include?('BB')
+  end
+end

--- a/app/models/meeting_creator/build_attributes.rb
+++ b/app/models/meeting_creator/build_attributes.rb
@@ -1,0 +1,94 @@
+# Use with ::build_from and pass a RawMeeting
+# Takes a raw meeting, and returns attributes with which to create a Meeting
+# For every Meeting attribute, selects the proper attribute builder,
+# defaulting to simply passing through the raw attribute.
+class MeetingCreator::BuildAttributes
+  attr_reader :raw_meeting
+
+  def self.build_from(raw_meeting)
+    ba = new(raw_meeting)
+    ba.build
+  end
+
+  # Note, zip code, lat, and lng will come from geocoding done in Meeting
+  def self.meeting_attributes
+    [
+      :raw_meeting,
+      :group_name,
+      :day,
+      :closed,
+      :time,
+      :address_1,
+      :address_2,
+      :notes,
+      :district,
+      :city,
+      :state,
+      :phone,
+
+      # 'Features'
+      :asl,
+      :accessible,
+      :non_smoking,
+      :sitter,
+      # 'Format'
+      :speaker,
+      :step,
+      :big_book,
+      :grapevine,
+      :traditions,
+      :candlelight,
+      :beginners,
+      # 'Language'
+      :spanish,
+      :french,
+      :polish,
+      # 'Focus'
+      :men,
+      :women,
+      :gay,
+      :young_people
+    ]
+  end
+
+  def initialize(raw_meeting)
+    @raw_meeting = raw_meeting
+  end
+
+  # Loop through the meeting_attributes. Find a handler for each, call that
+  # handler, and build up a hash with the attribute and the extracted value.
+  def build
+    self.class.meeting_attributes
+        .each_with_object({}) do |attribute, attributes|
+      handler = determine_handler(attribute)
+      extracted_value = extract_value(handler, attribute)
+      attributes[attribute] = extracted_value
+    end
+  end
+
+  def extract_value(handler, attribute)
+    if handler == passthru_handler
+      # The passthrough handler has to know which attribute to pass through
+      # from the raw_meeting.
+      handler.extract(raw_meeting, attribute)
+    else
+      handler.extract(raw_meeting)
+    end
+  end
+
+  def passthru_handler
+    MeetingCreator::PassthroughExtractor
+  end
+
+  # Go find a handler of the form:
+  #   MeetingCreator:<Attribute>Extractor
+  # If you can't find one, use:
+  #   MeetingCreator::PassthroughExtractor
+  def determine_handler(attribute)
+    base = attribute.to_s.titleize.delete(' ')
+    base = 'MeetingCreator::' + base + 'Extractor'
+    base.constantize
+  rescue NameError
+    passthru_handler
+  end
+end

--- a/app/models/meeting_creator/candlelight_extractor.rb
+++ b/app/models/meeting_creator/candlelight_extractor.rb
@@ -1,0 +1,5 @@
+class MeetingCreator::CandlelightExtractor
+  def self.extract(raw_meeting)
+    raw_meeting.codes.include?('CA')
+  end
+end

--- a/app/models/meeting_creator/closed_extractor.rb
+++ b/app/models/meeting_creator/closed_extractor.rb
@@ -1,0 +1,5 @@
+class MeetingCreator::ClosedExtractor
+  def self.extract(raw_meeting)
+    raw_meeting.codes =~ /(.*C[^A].*)|(.*C$)/
+  end
+end

--- a/app/models/meeting_creator/french_extractor.rb
+++ b/app/models/meeting_creator/french_extractor.rb
@@ -1,0 +1,5 @@
+class MeetingCreator::FrenchExtractor
+  def self.extract(raw_meeting)
+    raw_meeting.codes.include?('Frn')
+  end
+end

--- a/app/models/meeting_creator/gay_extractor.rb
+++ b/app/models/meeting_creator/gay_extractor.rb
@@ -1,0 +1,5 @@
+class MeetingCreator::GayExtractor
+  def self.extract(raw_meeting)
+    raw_meeting.codes =~ /(G[^V]|.*G$)/
+  end
+end

--- a/app/models/meeting_creator/grapevine_extractor.rb
+++ b/app/models/meeting_creator/grapevine_extractor.rb
@@ -1,0 +1,5 @@
+class MeetingCreator::GrapevineExtractor
+  def self.extract(raw_meeting)
+    raw_meeting.codes.include?('GV')
+  end
+end

--- a/app/models/meeting_creator/men_extractor.rb
+++ b/app/models/meeting_creator/men_extractor.rb
@@ -1,0 +1,5 @@
+class MeetingCreator::MenExtractor
+  def self.extract(raw_meeting)
+    raw_meeting.codes.include?('M')
+  end
+end

--- a/app/models/meeting_creator/non_smoking_extractor.rb
+++ b/app/models/meeting_creator/non_smoking_extractor.rb
@@ -1,0 +1,5 @@
+class MeetingCreator::NonSmokingExtractor
+  def self.extract(raw_meeting)
+    raw_meeting.codes =~ /(^n.*)|.*[^pr]n.*/
+  end
+end

--- a/app/models/meeting_creator/notes_extractor.rb
+++ b/app/models/meeting_creator/notes_extractor.rb
@@ -1,0 +1,11 @@
+class MeetingCreator::NotesExtractor
+  def self.extract(raw_meeting)
+    notes_match = raw_meeting.address.match(notes_matcher)
+    notes = notes_match ? notes_match.to_s : ""
+    notes.delete(')(')
+  end
+
+  def self.notes_matcher
+    /\(.+\)/
+  end
+end

--- a/app/models/meeting_creator/passthrough_extractor.rb
+++ b/app/models/meeting_creator/passthrough_extractor.rb
@@ -1,0 +1,5 @@
+class MeetingCreator::PassthroughExtractor
+  def self.extract(raw_meeting, attribute)
+    raw_meeting.send(attribute)
+  end
+end

--- a/app/models/meeting_creator/phone_extractor.rb
+++ b/app/models/meeting_creator/phone_extractor.rb
@@ -1,0 +1,10 @@
+class MeetingCreator::PhoneExtractor
+  def self.extract(raw_meeting)
+    matched = raw_meeting.address.match(phone_matcher)
+    matched ? matched.to_s : ''
+  end
+
+  def self.phone_matcher
+    /\d{3}(-\d{3})?-\d{4}/
+  end
+end

--- a/app/models/meeting_creator/polish_extractor.rb
+++ b/app/models/meeting_creator/polish_extractor.rb
@@ -1,0 +1,5 @@
+class MeetingCreator::PolishExtractor
+  def self.extract(raw_meeting)
+    raw_meeting.codes.include?('Pol')
+  end
+end

--- a/app/models/meeting_creator/raw_meeting_extractor.rb
+++ b/app/models/meeting_creator/raw_meeting_extractor.rb
@@ -1,0 +1,6 @@
+class MeetingCreator::RawMeetingExtractor
+  # just for consistency, folks. maybe this will change
+  def self.extract(raw_meeting)
+    raw_meeting
+  end
+end

--- a/app/models/meeting_creator/sitter_extractor.rb
+++ b/app/models/meeting_creator/sitter_extractor.rb
@@ -1,0 +1,5 @@
+class MeetingCreator::SitterExtractor
+  def self.extract(raw_meeting)
+    raw_meeting.codes =~ /.*Sit.*/
+  end
+end

--- a/app/models/meeting_creator/spanish_extractor.rb
+++ b/app/models/meeting_creator/spanish_extractor.rb
@@ -1,0 +1,5 @@
+class MeetingCreator::SpanishExtractor
+  def self.extract(raw_meeting)
+    raw_meeting.codes.include?('Spn')
+  end
+end

--- a/app/models/meeting_creator/speaker_extractor.rb
+++ b/app/models/meeting_creator/speaker_extractor.rb
@@ -1,0 +1,5 @@
+class MeetingCreator::SpeakerExtractor
+  def self.extract(raw_meeting)
+    raw_meeting.codes.include?('SP')
+  end
+end

--- a/app/models/meeting_creator/state_extractor.rb
+++ b/app/models/meeting_creator/state_extractor.rb
@@ -1,0 +1,5 @@
+class MeetingCreator::StateExtractor
+  def self.extract(raw_meeting)
+    'CO'
+  end
+end

--- a/app/models/meeting_creator/step_extractor.rb
+++ b/app/models/meeting_creator/step_extractor.rb
@@ -1,0 +1,5 @@
+class MeetingCreator::StepExtractor
+  def self.extract(raw_meeting)
+    raw_meeting.codes.include?('ST')
+  end
+end

--- a/app/models/meeting_creator/time_extractor.rb
+++ b/app/models/meeting_creator/time_extractor.rb
@@ -1,0 +1,5 @@
+class MeetingCreator::TimeExtractor
+  def self.extract(raw_meeting)
+    TimeConverter.to_dec(raw_meeting.time)
+  end
+end

--- a/app/models/meeting_creator/traditions_extractor.rb
+++ b/app/models/meeting_creator/traditions_extractor.rb
@@ -1,0 +1,5 @@
+class MeetingCreator::TraditionsExtractor
+  def self.extract(raw_meeting)
+    raw_meeting.codes =~ /(.*[^S]T.*)|(^T.*)/
+  end
+end

--- a/app/models/meeting_creator/women_extractor.rb
+++ b/app/models/meeting_creator/women_extractor.rb
@@ -1,0 +1,5 @@
+class MeetingCreator::WomenExtractor
+  def self.extract(raw_meeting)
+    raw_meeting.codes.include?('W')
+  end
+end

--- a/app/models/meeting_creator/young_people_extractor.rb
+++ b/app/models/meeting_creator/young_people_extractor.rb
@@ -1,0 +1,5 @@
+class MeetingCreator::YoungPeopleExtractor
+  def self.extract(raw_meeting)
+    raw_meeting.codes.include?('Y')
+  end
+end

--- a/app/models/scrape_daccaa.rb
+++ b/app/models/scrape_daccaa.rb
@@ -19,6 +19,7 @@ class ScrapeDaccaa
   def make_meetings(parsed)
     return false if !update_needed?
     return false if !valid_headers?
+
     current_raw = create_raw_meetings
     self.meta.set_updated
     current_raw
@@ -34,27 +35,27 @@ class ScrapeDaccaa
       puts "Done!"
       true
     else
-      Rails.logger.error "Bad Headers: #{@headers.retrieved_headers}"
+      Rails.logger.error { "Bad Headers: #{@headers.retrieved_headers}" }
       false
     end
   end
 
   def url
-    url = "http://www.daccaa.org/query.asp"
+    "http://www.daccaa.org/query.asp"
   end
 
   def get_page
     RestClient.post(url, {
-    'txtGroup'=>'',
-    'cboDay'=>'0',
-    'cboStartTime'=>'All',
-    'cboEndTime'=>'All',
-    'txtCity'=>'',
-    'cboMeetingType'=>'All',
-    'cboMeetingFormat'=>'All',
-    'cboSpecialMeeting'=>'All',
-    'cboDistrict'=>'All',
-    'cmdFindMeetings'=>'Find Meetings'
+      'txtGroup'=>'',
+      'cboDay'=>'0',
+      'cboStartTime'=>'All',
+      'cboEndTime'=>'All',
+      'txtCity'=>'',
+      'cboMeetingType'=>'All',
+      'cboMeetingFormat'=>'All',
+      'cboSpecialMeeting'=>'All',
+      'cboDistrict'=>'All',
+      'cmdFindMeetings'=>'Find Meetings'
     })
   end
 
@@ -74,5 +75,4 @@ class ScrapeDaccaa
       "rows: " => "#{self.raw_rows.object_id}: #{self.raw_rows.count} rows"
     }
   end
-
 end

--- a/config/travis.database.yml
+++ b/config/travis.database.yml
@@ -1,0 +1,3 @@
+test:
+  adapter: postgresql
+  database: travis_ci_test

--- a/lib/tasks/scrub.rake
+++ b/lib/tasks/scrub.rake
@@ -1,10 +1,8 @@
-require Rails.root.join('./app/models/meeting/extract_phone.rb').to_s
-
 namespace :scrub do
   desc 'extract and store phone number'
   task phone: :environment do
     Meeting.all.each do |meeting|
-      ExtractPhone.extract! meeting
+      Meeting::ExtractPhone.extract! meeting
     end
   end
 end

--- a/spec/models/meeting/extract_phone_spec.rb
+++ b/spec/models/meeting/extract_phone_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
-require Rails.root.join('./app/models/meeting/extract_phone.rb').to_s
 
-describe ExtractPhone do
+describe Meeting::ExtractPhone do
   it 'extracts a trailing phone number' do
     meeting = FactoryBot.create :meeting,
       address_1: "8250 W. 80th Ave. Unit 12, 303-420-6560"

--- a/spec/models/meeting_creator/address1_extractor_spec.rb
+++ b/spec/models/meeting_creator/address1_extractor_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe MeetingCreator::Address1Extractor do
+  addresses_with_extracted = {
+    '123 Fake St.' => '123 Fake St.',
+    '3600 S. Clarkson (NE of Ch)' => '3600 S. Clarkson St.',
+    '3355 S. Wadsworth #H125, 989-2816' => '3355 S. Wadsworth Blvd.',
+    '8817 S. Broadway (Ch)' => '8817 S. Broadway',
+    '1311 York St., 322-3674' => '1311 York St.',
+    '5455 W. 38th Ave. Unit M' => '5455 W. 38th Ave.',
+    '1801 Sunset Pl. Ste B' => '1801 Sunset Pl.',
+
+    # testing no spaces before notes
+    '10151 W. 26th Ave.(Restaurant)' => '10151 W. 26th Ave.',
+
+    # ensuring Wadsworth Blvd. doesn't become Blvd. Blvd.
+    '3355 S. Wadsworth Blvd. #H-125, 989-2816' => '3355 S. Wadsworth Blvd.',
+    '7964 S. Depew (Platte Canyon/Chatfield)' => '7964 S. Depew St.',
+
+    # yes, 3 different wadsworths
+    '1050 Wadsworth Bl. 303-238-5693' => '1050 Wadsworth Blvd.',
+    '147 S. 2nd Place, 303-659-9953' => '147 S. 2nd Place',
+    '1200 South St.(Ch bsmt #104)' => "1200 South St."
+  }
+
+  addresses_with_extracted.each do |address_in, expected_output|
+    it "extracts #{expected_output} from #{address_in}" do
+      raw_meeting = OpenStruct.new(address: address_in)
+      result = described_class.extract(raw_meeting)
+
+      expect(result).to eql(expected_output)
+    end
+  end
+end

--- a/spec/models/meeting_creator/address2_extractor_spec.rb
+++ b/spec/models/meeting_creator/address2_extractor_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+describe MeetingCreator::Address2Extractor do
+  addresses_with_extracted = {
+    '123 Fake St.' => '',
+    '3600 S. Clarkson (NE of Ch)' => '',
+    '3355 S. Wadsworth #H125, 989-2816' => '#H125',
+    '8817 S. Broadway (Ch)' => '',
+    '1311 York St., 322-3674' => '',
+    '5455 W. 38th Ave. Unit M' => 'Unit M',
+    '1801 Sunset Pl. Ste B' => 'Ste B',
+
+    # testing no spaces before notes
+    '10151 W. 26th Ave.(Restaurant)' => '',
+
+    # a '#' with a dash
+    '3355 S. Wadsworth Blvd. #H-125, 989-2816' => '#H-125',
+    '147 S. 2nd Place, 303-659-9953' => '',
+    '1200 South St.(Ch bsmt #104)' => ''
+  }
+
+  addresses_with_extracted.each do |raw_address, desired_output|
+    it "extracts '#{desired_output}' from '#{raw_address}'" do
+      raw_meeting = OpenStruct.new(address: raw_address)
+
+      result = described_class.extract(raw_meeting)
+
+      expect(result).to eql(desired_output)
+    end
+  end
+end

--- a/spec/models/meeting_creator/build_attributes_spec.rb
+++ b/spec/models/meeting_creator/build_attributes_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+# Defining a fake attribute handler-- we don't want to mess the class up for
+# tests that target these handlers specifically.
+class MeetingCreator::SizeExtractor
+  def self.extract(_raw_meeting)
+    'Large'
+  end
+end
+
+describe MeetingCreator::BuildAttributes do
+  before :all do
+    @fake_raw_meeting = OpenStruct.new(
+      address: '123 Evergreen Terrace',
+      color: 'Pink'
+    )
+  end
+
+  it 'passes through the attribute if no handler is available' do
+    allow(described_class).to receive(:meeting_attributes).and_return(
+      [:size, :color]
+    )
+
+    attributes = described_class.build_from(@fake_raw_meeting)
+
+    expect(defined? MeetingCreator::ColorExtractor).to be_falsey
+    expect(attributes[:color]).to eq('Pink')
+  end
+
+  it 'uses custom handler if available' do
+    allow(described_class).to receive(:meeting_attributes).and_return(
+      [:size, :color]
+    )
+    allow(MeetingCreator::SizeExtractor).to receive(:extract)
+
+    described_class.build_from(@fake_raw_meeting)
+
+    expect(MeetingCreator::SizeExtractor).to have_received(:extract).exactly(1)
+                                                                    .times
+  end
+
+  context 'determine handler - ' do
+    it 'gets RawMeeting for :raw_meeting' do
+      handler = described_class.new('x').determine_handler(:raw_meeting)
+      expect(handler).to eql(MeetingCreator::RawMeetingExtractor)
+    end
+  end
+end

--- a/spec/models/meeting_creator_spec.rb
+++ b/spec/models/meeting_creator_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe MeetingCreator do
     end
 
     it "extracts first line address" do
-      expect(@meeting.address_1).to eq("3355 S. Wadsworth Bl. #H-127")
+      expect(@meeting.address_1).to eq('3355 S. Wadsworth Blvd.')
     end
 
     it "knows open status" do
@@ -42,21 +42,20 @@ RSpec.describe MeetingCreator do
 
     before :each do
       allow_any_instance_of(Meeting).to receive(:geocode).and_return(nil)
-      @mc = MeetingCreator.new(@raw)
-      # @meeting = mc.create
+      @meeting = described_class.new(@raw).create
     end
 
     it "parses address_1" do
-      expect(@mc.address_1).to eql("1200 South St.")
+      expect(@meeting.address_1).to eql("1200 South St.")
     end
 
     it "parses notes" do
-      expect(@mc.notes).to eql("Ch bsmt #104")
+      expect(@meeting.notes).to eql("Ch bsmt #104")
     end
 
     it "is men's" do
-      expect(@mc.build_attributes[:men]).to be_truthy
-      expect(@mc.build_attributes[:gay]).to be_falsey
+      expect(@meeting.men).to be_truthy
+      expect(@meeting.gay).to be_falsey
     end
   end
 
@@ -66,23 +65,23 @@ RSpec.describe MeetingCreator do
         group_name: "A New Day",
         address: "8250 W. 80th Ave. Unit 12, 303-420-6560",
       )
-      @mc = MeetingCreator.new(@raw)
+      @meeting = MeetingCreator.new(@raw).create
     end
 
     it "parses address_1" do
-      expect(@mc.address_1).to eql("8250 W. 80th Ave.")
+      expect(@meeting.address_1).to eql("8250 W. 80th Ave.")
     end
 
     it "parses address_2" do
-      expect(@mc.address_2).to eql("Unit 12")
+      expect(@meeting.address_2).to eql("Unit 12")
     end
 
     it "parses notes" do
-      expect(@mc.notes).to_not be_present
+      expect(@meeting.notes).to_not be_present
     end
 
     it "parses phone number" do
-      expect(@mc.phone).to eql("303-420-6560")
+      expect(@meeting.phone).to eql("303-420-6560")
     end
   end
 
@@ -92,19 +91,19 @@ RSpec.describe MeetingCreator do
         group_name: "Buckeye Easy Does It",
         address: "16732 E Iliff Av (Shop Ctr) 695-7766"
       )
-      @mc = MeetingCreator.new(@raw)
+      @meeting = MeetingCreator.new(@raw).create
     end
 
     it "parses address_1" do
-      expect(@mc.address_1).to eql("16732 E Iliff Av")
+      expect(@meeting.address_1).to eql("16732 E Iliff Av")
     end
 
     it "parses notes" do
-      expect(@mc.notes).to eql("Shop Ctr")
+      expect(@meeting.notes).to eql("Shop Ctr")
     end
 
     it "parses phone number" do
-      expect(@mc.phone).to eql("695-7766")
+      expect(@meeting.phone).to eql("695-7766")
     end
   end
 
@@ -114,23 +113,23 @@ RSpec.describe MeetingCreator do
         group_name: "231 Buckley",
         address: "15210 E 6th Ave, Unit 1, 343-4994"
       )
-      @mc = MeetingCreator.new(@raw)
+      @meeting = MeetingCreator.new(@raw).create
     end
 
     it "parses address_1" do
-      expect(@mc.address_1).to eql("15210 E 6th Ave")
+      expect(@meeting.address_1).to eql("15210 E 6th Ave")
     end
 
     it "parses address_2" do
-      expect(@mc.address_2).to eql("Unit 1")
+      expect(@meeting.address_2).to eql("Unit 1")
     end
 
     it "parses notes" do
-      expect(@mc.notes).to eql("")
+      expect(@meeting.notes).to eql("")
     end
 
     it "parses phone number" do
-      expect(@mc.phone).to eql("343-4994")
+      expect(@meeting.phone).to eql("343-4994")
     end
   end
 end


### PR DESCRIPTION
- Create meeting_creator folder to namespace
- Create build_attributes to dispatch all the parsing
- Create invidual parsers, called extractors, for every Meeting
attribute
- Create default passthru extractor
- Add more functionality to address1, address2, and phone parsing
    - Some of this didn't exist at all yet
    - Should be pretty good right now, but not exhaustively tested
and probably not perfect
- Also properly namespace the extract phone class that was made for the
after-the-fact scrubbing. Repoint its rake task.
- Made some tweaks due to travis not running anymore
    - Add travis.database.yml
    - Tweak travis.yml